### PR TITLE
Fixed HTML entity for ellipsis when saving domain name change.

### DIFF
--- a/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
@@ -28,7 +28,7 @@ class Domain extends Component {
       <label className={styles.Domain}>
         Domain:&nbsp;
         {this.state.submitted ? (
-          <span>Saving&elipse;</span>
+          <span>Saving&hellip;</span>
         ) : this.props.site.domain && !this.state.editing ? (
           <span className={styles.Name} onClick={this.handleEdit}>
             http://{this.state.domain}


### PR DESCRIPTION
Fixed the entity encoding for the ellipsis used in the saving domain name message, as it was broken before.