### PR TITLE
Bugfix/fix domain setting

### DIFF
--- a/src/apps/properties/src/store/sitesDomain.js
+++ b/src/apps/properties/src/store/sitesDomain.js
@@ -2,7 +2,7 @@ import { request } from '../../../../util/request'
 
 export function updateDomain(siteZUID, domain) {
   return dispatch => {
-    return request(`${CONFIG.API_ACCOUNTS}/instances/${siteZUID}`, {
+    return request(`${CONFIG.API_ACCOUNTS}/instances/${siteZUID}?updateDomain=true`, {
       method: 'PUT',
       json: true,
       body: { domain }


### PR DESCRIPTION
This adds an extra parameter `updateDomain=true` onto the `PUT` API call to update the domain for a site.  Required to trigger the logic in this PR for accounts-api: https://github.com/zesty-io/accounts-api/pull/13

Note, some work will be needed here in accounts UI to deal with processing the message that comes back from accounts-api when the domain chosen is already taken.

Example attached showing what happens when a domain that's already taken is selected.
![screen shot 2018-05-31 at 11 02 48 am](https://user-images.githubusercontent.com/94062/40799366-3ff865e2-64c2-11e8-98dc-630d1b19ae43.png)
