### PR TITLE
fixed domain no longer in edit mode after saving changes

### DIFF
--- a/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
@@ -32,8 +32,7 @@ export default class Domain extends Component {
               this.setState({
                 editing: true
               })
-            }}
-          >
+            }}>
             {this.props.domain}
             <i className="fa fa-pencil" />
           </span>
@@ -67,16 +66,20 @@ export default class Domain extends Component {
     this.props
       .dispatch(updateDomain(this.props.siteZUID, strippedDomain))
       .then(domain => {
-        this.setState({
-          domain,
-          submitted: false,
-          editing: false
-        })
-        this.props.dispatch(
-          notify({
-            message: `Your domain has been set to ${domain}`,
-            type: 'success'
-          })
+        return this.setState(
+          {
+            domain,
+            submitted: false,
+            editing: false
+          },
+          () => {
+            this.props.dispatch(
+              notify({
+                message: `Your domain has been set to ${domain}`,
+                type: 'success'
+              })
+            )
+          }
         )
       })
       .catch(data => {


### PR DESCRIPTION
## Previous functionality
after editing a domain name and saving it would remain in 'edit mode'

## Corrected functionality
domain is displayed properly (not in a text input) after changes have been saved