### PR TITLE
fixed: blank card being created after blueprint action

### DIFF
--- a/src/apps/properties/src/store/sites.js
+++ b/src/apps/properties/src/store/sites.js
@@ -155,7 +155,6 @@ export function updateSite(siteZUID, payload) {
       body: payload
     })
       .then(res => {
-        console.log(res.data)
         dispatch({
           type: 'UPDATE_SITE_SUCCESS',
           site: res.data


### PR DESCRIPTION
## pervious behavior
a blank card was showing in the properties view after a blueprint was selected fo changed for a site

## current behavior
blueprint selection no longer creates this side-effect