### PR TITLE
fixed: blueprint selection redirect

### DIFF
--- a/src/apps/properties/src/views/PropertyBlueprint/PropertyBlueprint.js
+++ b/src/apps/properties/src/views/PropertyBlueprint/PropertyBlueprint.js
@@ -82,7 +82,7 @@ class PropertyBlueprint extends Component {
         })
       )
       .then(data => {
-        if (this.props.siteBlueprint) {
+        if (!this.props.siteBlueprint) {
           window.open(
             `${CONFIG.MANAGER_URL_PROTOCOL}${this.props.randomHashID}${
               CONFIG.MANAGER_URL


### PR DESCRIPTION
## previous behavior
selecting a new blueprint for an instance always resulted in a redirect

## current behavior
selecting a blueprint for an instance only redirects if it's adding a blueprint for the first time.