### PR TITLE
added: checks to make sure isOwner before delete icon is shown

### DIFF
--- a/src/apps/properties/src/views/PropertyOverview/components/Users/UserRow/UserRow.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Users/UserRow/UserRow.js
@@ -26,16 +26,18 @@ export default class UserRow extends Component {
               <React.Fragment>
                 <i className="fa fa-fort-awesome" />
                 <span className={styles.Owner}>Owner</span>
-                <i
-                  className={styles.trash + ' fa fa-trash-o'}
-                  aria-hidden="true"
-                  onClick={() =>
-                    this.removeUserFromInstance(
-                      this.props.ZUID,
-                      this.props.role.ZUID
-                    )
-                  }
-                />
+                {this.props.isOwner && (
+                  <i
+                    className={styles.trash + ' fa fa-trash-o'}
+                    aria-hidden="true"
+                    onClick={() =>
+                      this.removeUserFromInstance(
+                        this.props.ZUID,
+                        this.props.role.ZUID
+                      )
+                    }
+                  />
+                )}
               </React.Fragment>
             ) : (
               <span className={styles.select}>
@@ -47,8 +49,7 @@ export default class UserRow extends Component {
                       .map(item => {
                         return { value: item.ZUID, text: item.name }
                       })[0]
-                  }
-                >
+                  }>
                   {this.props.siteRoles.map(role => {
                     return (
                       <Option

--- a/src/apps/properties/src/views/PropertyOverview/components/Users/Users.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Users/Users.js
@@ -101,6 +101,7 @@ export default class Users extends Component {
                           siteRoles={this.props.siteRoles}
                           dispatch={this.props.dispatch}
                           isAdmin={this.props.isAdmin}
+                          isOwner={this.props.isOwner}
                           {...user}
                         />
                       )


### PR DESCRIPTION
## Previous Behavior
any admin was able to click the delete icon next to an owner in the instance overview

## Current Behavior
the delete icon for a user in an instance only shows up if a user is an owner on that site.