### PR TITLE
fixed: height of content cut off bottom of last row of grid

### DIFF
--- a/src/apps/properties/src/views/PropertyBlueprint/PropertyBlueprint.less
+++ b/src/apps/properties/src/views/PropertyBlueprint/PropertyBlueprint.less
@@ -2,7 +2,7 @@
 
 .BlueprintView {
   overflow-y: scroll;
-  height: 100%;
+  height: 86vh;
   padding: 2rem;
   header {
     display: flex;


### PR DESCRIPTION
## Previous behavior
the last row of the blueprint selection grid had the bottom of the cards cut off at some resolutions.

![screen shot 2018-06-18 at 10 17 39 am](https://user-images.githubusercontent.com/26661451/41551492-dfb2510c-72e0-11e8-9d98-02822ef9f48d.png)

## Current behavior
heigh is now set correctly and cards are fully visible in select blueprint view.

![screen shot 2018-06-18 at 10 17 19 am](https://user-images.githubusercontent.com/26661451/41551490-db95d4c2-72e0-11e8-968e-1615b433548d.png)
