### PR TITLE
added: handle 403 message too many failed login attempts

### DIFF
--- a/src/shell/views/Login/Login.js
+++ b/src/shell/views/Login/Login.js
@@ -1,32 +1,31 @@
-import React, { Component } from "react";
-import { connect } from "react-redux";
-import { Link, withRouter } from "react-router-dom";
-import qs from "qs";
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { Link, withRouter } from 'react-router-dom'
+import qs from 'qs'
 
-import styles from "./Login.less";
+import styles from './Login.less'
 
-import { request } from "../../../util/request";
-import { login } from "../../store/auth";
-import { fetchUser } from "../../store/user";
-
+import { request } from '../../../util/request'
+import { login } from '../../store/auth'
+import { fetchUser } from '../../store/user'
 class Login extends Component {
   constructor(props) {
-    super();
+    super()
     this.state = {
       submitted: false,
-      message: ""
-    };
+      message: ''
+    }
   }
   componentDidMount() {
-    const invite = qs.parse(window.location.search.substr(1));
+    const invite = qs.parse(window.location.search.substr(1))
     if (invite.invited) {
       this.props.dispatch({
-        type: "USER_INVITED",
+        type: 'USER_INVITED',
         invite: {
           email: invite.email,
           invited: invite.invited
         }
-      });
+      })
     }
   }
   render() {
@@ -71,8 +70,7 @@ class Login extends Component {
               <Button
                 tabIndex="3"
                 onClick={this.handleLogin}
-                disabled={this.state.submitted}
-              >
+                disabled={this.state.submitted}>
                 {this.state.submitted ? (
                   <React.Fragment>
                     Logging You In&nbsp;
@@ -117,14 +115,14 @@ class Login extends Component {
           </main>
         </div>
       </section>
-    );
+    )
   }
   handleLogin = evt => {
-    evt.preventDefault();
+    evt.preventDefault()
 
     this.setState({
       submitted: true
-    });
+    })
 
     this.props
       .dispatch(
@@ -132,35 +130,35 @@ class Login extends Component {
       )
       .then(json => {
         if (json.code === 200) {
-          this.props.history.push("/instances");
+          this.props.history.push('/instances')
         } else if (json.code === 202) {
-          this.props.history.push("/login/2fa");
+          this.props.history.push('/login/2fa')
         } else {
           this.setState({
             submitted: false,
-            message: "There was a problem logging you in"
-          });
+            message: 'There was a problem logging you in'
+          })
           this.props.dispatch({
-            type: "FETCH_AUTH_ERROR",
+            type: 'FETCH_AUTH_ERROR',
             auth: false
-          });
+          })
         }
       })
       .catch(err => {
-        console.error(err);
+        console.error(err)
         if (err === 403) {
           this.setState({
             submitted: false,
-            message: "Too many failed login attempts"
-          });
+            message: 'Too many failed login attempts'
+          })
         } else {
           this.setState({
             submitted: false,
-            message: "There was a problem logging you in"
-          });
+            message: 'There was a problem logging you in'
+          })
         }
-      });
-  };
+      })
+  }
 }
 
-export default withRouter(connect(state => state)(Login));
+export default withRouter(connect(state => state)(Login))


### PR DESCRIPTION
## Previous Behavior
In the event of a 403 error due to too many failed login attempts a generic error would display

## Current Behavior
A specific failure message is displayed stating too many failed login attempts have been submitted.
![screen shot 2018-06-19 at 2 28 19 pm](https://user-images.githubusercontent.com/26661451/41625263-0e7a403e-73cd-11e8-9c6e-f9f6e0b09b60.png)
