### PR TITLE
added: prettier config

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,11 @@
     "style-loader": "0.20.3",
     "webpack": "3.8.1"
   },
+  "prettier": {
+    "jsxBracketSameLine": true,
+    "singleQuote": true,
+    "tabWidth": 2,
+    "semi": false
+  },
   "false": {}
 }


### PR DESCRIPTION
## Previous Behavior
prettier formatting by default config values

## Current Behavior
configured to single quotes, no semicolon insertion, tabWidth of 2 sp, and JSX brackets aren't automatically new-lined.