### PR TITLE
fixed: images larger than typical cover images no longer break the ui

### DIFF
--- a/src/apps/blueprints/src/components/BlueprintCard/BlueprintCard.less
+++ b/src/apps/blueprints/src/components/BlueprintCard/BlueprintCard.less
@@ -17,9 +17,11 @@
     margin: 0;
     display: flex;
     flex-direction: column;
-
+    height: 233px;
     img {
       max-width: 100%;
+      max-height: 133px;
+      object-fit: cover;
     }
     p {
       margin: 1rem;


### PR DESCRIPTION
## Previous Behavior
If a cover image for a blueprint was selected that was taller than standard cover images it would break the card.
![screen shot 2018-06-25 at 10 48 37 am](https://user-images.githubusercontent.com/26661451/41867201-445287b8-7867-11e8-94b4-11902913b436.png)

## Current Behavior
The image selected for a blueprint cover displayed on the blueprint card is constrained to the correct dimensions. 
![screen shot 2018-06-25 at 10 58 24 am](https://user-images.githubusercontent.com/26661451/41867272-7f769c58-7867-11e8-8bb5-7873bed1d507.png)

