### PR TITLE
Domain message fix

### DIFF
--- a/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
@@ -32,8 +32,7 @@ export default class Domain extends Component {
               this.setState({
                 editing: true
               })
-            }}
-          >
+            }}>
             {this.props.domain}
             <i className="fa fa-pencil" />
           </span>
@@ -74,7 +73,7 @@ export default class Domain extends Component {
         })
         this.props.dispatch(
           notify({
-            message: `Your domain has been set to ${domain}`,
+            message: `Your domain has been set to ${strippedDomain}`,
             type: 'success'
           })
         )


### PR DESCRIPTION
## Previous Behavior
the domain name in the success message would display as 'undefined'

## Current Behavior
the correct, new domain name is displayed in the success notification.