### PR TITLE
added: validity check before fetching an instance blueprint

### DIFF
--- a/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
+++ b/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
@@ -213,10 +213,7 @@ class PropertyOverview extends Component {
       })
     })
     // validity check blueprint ID before fetching
-    if (
-      typeof props.site.blueprintID === 'number' &&
-      props.site.blueprintID !== 0
-    ) {
+    if (parseInt(props.site.blueprintID)) {
       props.dispatch(fetchBlueprint(props.site.blueprintID)).then(() => {
         this.setState({
           loadingBlueprint: false


### PR DESCRIPTION
## Previous Behavior
a fetch for an instances blueprint would kick off when the overview view would load, returning an undefined blueprint if there was no blueprint set for an instance. this would cause a type error and clutters up our error reporting

## Proposed Behavior
a validity check is made on the blueprint ID before the fetch is executed