### PR TITLE
Fixes error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Build environments-
 
     npm run build-development
     npm run build-stage
-    npm run build-prod
+    npm run build-production
 
 
 ### Deploying


### PR DESCRIPTION
There was no `npm run build-dev` script, changed to `npm run build-development`.