### PR TITLE
Blueprint update fix

### DIFF
--- a/src/apps/properties/src/store/sites.js
+++ b/src/apps/properties/src/store/sites.js
@@ -34,7 +34,7 @@ export function sites(state = {}, action) {
         ...state,
         [action.siteZUID]: {
           ...state[action.siteZUID],
-          blueprint: action.blueprintID
+          blueprintID: action.blueprintID
         }
       }
     default:


### PR DESCRIPTION
## Previous Behavior
when a user would update a blueprint the wrong key would be changed in state and the old blueprint would be displayed in the instance overview.

## Proposed Behavior
when the blueprint is changed, the correct blueprint is displayed in the instance overview.