### PR TITLE
added: logic to handle instance after site invitiation acceptance or …

### DIFF
--- a/src/apps/properties/src/views/PropertiesList/components/ColumnList/components/InviteRow/InviteRow.js
+++ b/src/apps/properties/src/views/PropertiesList/components/ColumnList/components/InviteRow/InviteRow.js
@@ -18,15 +18,13 @@ export default connect()(function InviteRow(props) {
       <Button
         type="save"
         className={styles.action}
-        onClick={() => handleAccept(props)}
-      >
+        onClick={() => handleAccept(props)}>
         <i className="fa fa-check" aria-hidden="true" />
       </Button>
       <Button
         type="cancel"
         className={styles.action}
-        onClick={() => handleDecline(props)}
-      >
+        onClick={() => handleDecline(props)}>
         <i className="fa fa-ban" aria-hidden="true" />
       </Button>
     </span>
@@ -35,11 +33,35 @@ export default connect()(function InviteRow(props) {
 
 function handleAccept(props) {
   props.dispatch(acceptInvite(props.site.inviteZUID)).then(data => {
-    console.log('accepted invite', data)
+    this.props.dispatch(fetchSites()).then(data => {
+      const invitedSite = data.data.filter(site => {
+        return site.ZUID === this.props.site.ZUID
+      })
+      return this.props.history.push(
+        `/instances/${this.props.site.ZUID}?invited=true`
+      )
+    })
+    this.props.dispatch(
+      notify({
+        message: `You accepted your invite to ${this.props.site.name}`,
+        type: 'success',
+        timeout: 6000
+      })
+    )
   })
 }
 function handleDecline(props) {
   props.dispatch(declineInvite(props.site.inviteZUID)).then(data => {
-    console.log('declined invite', data)
+    this.props
+      .dispatch(declineInvite(this.props.site.inviteZUID))
+      .then(data => {
+        this.props.dispatch(
+          notify({
+            message: `You have declined your invite to ${this.props.site.name}`,
+            type: 'info'
+          })
+        )
+        this.props.dispatch(fetchSites())
+      })
   })
 }


### PR DESCRIPTION
## Previous Behavior
accepting an invite to an instance in column view would not change the instance from an invite to a regular instance

## Proposed Behavior
the acceptance or decline of an invitation modifies the redux state to reflect that user's decision.