### PR TITLE
removed check for super prop that does not exist on roles currently

### DIFF
--- a/src/apps/properties/src/views/PropertyOverview/components/CompanyAccess/CompanyAccess.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/CompanyAccess/CompanyAccess.js
@@ -48,15 +48,13 @@ export default class CompanyAccess extends Component {
                 <Select onSelect={this.handleRole}>
                   <Option key="default" value="" text="Select Role" />
                   {this.props.siteRoles.map(role => {
-                    if (!role.systemRole.super) {
-                      return (
-                        <Option
-                          key={role.ZUID}
-                          value={role.ZUID}
-                          text={role.name}
-                        />
-                      )
-                    }
+                    return (
+                      <Option
+                        key={role.ZUID}
+                        value={role.ZUID}
+                        text={role.name}
+                      />
+                    )
                   })}
                 </Select>
                 <Button


### PR DESCRIPTION
A check for a 'super' prop on a role was added in error and caused problems with testing. This is a prop we will need when we start to work with advanced governance per @protometheus however is not currently necessary.