### PR TITLE
Aries bugfix/pass update

### DIFF
--- a/src/apps/account/src/views/Account/components/Password/Password.js
+++ b/src/apps/account/src/views/Account/components/Password/Password.js
@@ -1,6 +1,7 @@
 import { Component } from 'React'
 import { connect } from 'react-redux'
 import { notify } from '../../../../../../../shell/store/notifications'
+import { zConfirm } from '../../../../../../../shell/store/confirm'
 import { updatePassword } from '../../../../store'
 
 import styles from './Password.less'
@@ -113,8 +114,21 @@ class Password extends Component {
             })
           )
         } else {
+          // notify user
           // log out and sign in with new password
-          this.props.history.push('/logout')
+          this.props.dispatch(
+            zConfirm({
+              single: true,
+              confirmText: 'Go to login',
+              prompt:
+                'Your password has been changed, please log in with your new password',
+              callback: confirmed => {
+                if (confirmed) {
+                  this.props.history.push('/logout')
+                }
+              }
+            })
+          )
         }
       })
       .catch(() => {

--- a/src/shell/components/Confirm/Confirm.js
+++ b/src/shell/components/Confirm/Confirm.js
@@ -13,7 +13,10 @@ const Confirm = props => {
         <section className={cx(styles.Confirm, styles[props.kind])}>
           <h1>{props.prompt}</h1>
           <footer>
-            <ButtonGroup className={styles.buttons}>
+            <ButtonGroup
+              className={`${styles.buttons} ${
+                props.single ? styles.short : ''
+              }`}>
               <Button
                 id="confirmTrue"
                 type={props.kind}
@@ -27,7 +30,7 @@ const Confirm = props => {
                     aria-hidden="true"
                   />
                 )}
-                Yes
+                {props.confirmText || 'Yes'}
               </Button>
               <Button
                 id="confirmFalse"
@@ -35,6 +38,7 @@ const Confirm = props => {
                   props.callback(false)
                   props.dispatch({ type: REMOVE_CONFIRM })
                 }}
+                className={props.single ? styles.hide : ''}
                 text="No"
               />
             </ButtonGroup>

--- a/src/shell/components/Confirm/Confirm.less
+++ b/src/shell/components/Confirm/Confirm.less
@@ -23,6 +23,12 @@
       padding: 1rem 1rem 0 1rem;
       font-size: 1rem;
     }
+    .hide {
+      display: none;
+    }
+    .buttons.short {
+      display: block;
+    }
   }
 
   footer {


### PR DESCRIPTION
## Previous Behavior
password updates logged a user out and did not handle errors gracefully

## Proposed Behavior
a user get specific error messages from the API when attempting to change password and if it is successful is given a message and option to click through to use their new password to login.