### PR TITLE
Fix for users who did not select a blueprint

### DIFF
--- a/src/apps/properties/src/components/WebsiteCard/WebsiteCard.js
+++ b/src/apps/properties/src/components/WebsiteCard/WebsiteCard.js
@@ -56,8 +56,7 @@ export default props => {
             title={`Preview instance: ${site.name}`}
             href={`${CONFIG.PREVIEW_URL_PROTOCOL}${site.randomHashID}${
               CONFIG.PREVIEW_URL
-            }`}
-          >
+            }`}>
             <i className={'fa fa-eye'} aria-hidden="true" />
           </Url>
 
@@ -65,27 +64,31 @@ export default props => {
             <Url
               href={`http://${site.domain}`}
               target="_blank"
-              title="View live domain"
-            >
+              title="View live domain">
               <i className="fa fa-globe" aria-hidden="true" />
             </Url>
           ) : (
             <span />
           )}
-
-          <Url
-            className={styles.manager}
-            target="_blank"
-            title="Load instance manager"
-            href={`${CONFIG.MANAGER_URL_PROTOCOL}${site.randomHashID}${
-              CONFIG.MANAGER_URL
-            }`}
-          >
-            Open Manager&nbsp;<i
-              className="fa fa-external-link-square"
-              aria-hidden="true"
-            />
-          </Url>
+          {/* only display link to manager if a blueprint has been selected */}
+          {site.blueprintID !== null ? (
+            <Url
+              className={styles.manager}
+              target="_blank"
+              href={`${CONFIG.MANAGER_URL_PROTOCOL}${site.randomHashID}${
+                CONFIG.MANAGER_URL
+              }`}>
+              <i className="fa fa-external-link" aria-hidden="true" />&nbsp;Open
+              Manager
+            </Url>
+          ) : (
+            <AppLink
+              to={`/instances/${site.ZUID}/blueprint`}
+              className={styles.selectBlueprint}>
+              <i className="fa fa-file-code-o" aria-hidden="true" />
+              &nbsp;Select Blueprint
+            </AppLink>
+          )}
         </ButtonGroup>
       </CardFooter>
     </Card>

--- a/src/apps/properties/src/components/WebsiteCard/WebsiteCard.less
+++ b/src/apps/properties/src/components/WebsiteCard/WebsiteCard.less
@@ -80,7 +80,6 @@
       flex-basis: auto;
       display: grid;
       grid-template-columns: 35px 35px 35px 1fr;
-
       a {
         border-right: 1px solid @zesty-field-blue;
         padding: 9px;
@@ -93,6 +92,9 @@
         border: none;
         text-align: right;
         padding: 4px 9px;
+      }
+      .selectBlueprint {
+        font-weight: 900;
       }
     }
   }

--- a/src/apps/properties/src/views/PropertiesList/components/ColumnList/components/InstanceRow/InstanceRow.js
+++ b/src/apps/properties/src/views/PropertiesList/components/ColumnList/components/InstanceRow/InstanceRow.js
@@ -16,8 +16,7 @@ export default function InstanceRow(props) {
       />
       <AppLink
         className={cx(styles.action, styles.overview)}
-        to={`/instances/${site.ZUID}`}
-      >
+        to={`/instances/${site.ZUID}`}>
         {site.name}
       </AppLink>
 
@@ -27,20 +26,25 @@ export default function InstanceRow(props) {
         title={`Open instance preview: ${site.name}`}
         href={`${CONFIG.PREVIEW_URL_PROTOCOL}${site.randomHashID}${
           CONFIG.PREVIEW_URL
-        }`}
-      >
+        }`}>
         <i className={'fa fa-eye'} aria-hidden="true" />
       </Url>
-      <Url
-        className={styles.action}
-        target="_blank"
-        title="Open instance manager"
-        href={`${CONFIG.MANAGER_URL_PROTOCOL}${site.randomHashID}${
-          CONFIG.MANAGER_URL
-        }`}
-      >
-        <i className="fa fa-external-link-square" aria-hidden="true" />
-      </Url>
+      {site.blueprintID !== null ? (
+        <Url
+          className={styles.action}
+          target="_blank"
+          href={`${CONFIG.MANAGER_URL_PROTOCOL}${site.randomHashID}${
+            CONFIG.MANAGER_URL
+          }`}>
+          <i className="fa fa-external-link-square" aria-hidden="true" />
+        </Url>
+      ) : (
+        <AppLink
+          className={styles.action}
+          to={`/instances/${site.ZUID}/blueprint`}>
+          <i className="fa fa-file-code-o" aria-hidden="true" />
+        </AppLink>
+      )}
     </span>
   )
 }

--- a/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
+++ b/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
@@ -46,15 +46,23 @@ class PropertyOverview extends Component {
     return (
       <article className={styles.PropertyOverview}>
         <header className={styles.PropertyOverviewHeader}>
-          <Url
-            className={styles.manager}
-            target="_blank"
-            href={`${CONFIG.MANAGER_URL_PROTOCOL}${
-              this.props.site.randomHashID
-            }${CONFIG.MANAGER_URL}`}>
-            <i className="fa fa-external-link" aria-hidden="true" />&nbsp;Open
-            Manager
-          </Url>
+          {/* only display link to manager if a blueprint has been selected */}
+          {this.props.site.blueprintID !== null ? (
+            <Url
+              className={styles.manager}
+              target="_blank"
+              href={`${CONFIG.MANAGER_URL_PROTOCOL}${
+                this.props.site.randomHashID
+              }${CONFIG.MANAGER_URL}`}>
+              <i className="fa fa-external-link" aria-hidden="true" />&nbsp;Open
+              Manager
+            </Url>
+          ) : (
+            <AppLink to={`${this.props.site.ZUID}/blueprint`}>
+              <i className="fa fa-file-code-o" aria-hidden="true" />
+              &nbsp;Select Blueprint
+            </AppLink>
+          )}
           <Url
             className={styles.manager}
             target="_blank"

--- a/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
+++ b/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
@@ -58,7 +58,7 @@ class PropertyOverview extends Component {
               Manager
             </Url>
           ) : (
-            <AppLink to={`${this.props.site.ZUID}/blueprint`}>
+            <AppLink to={`/instances/${this.props.site.ZUID}/blueprint`}>
               <i className="fa fa-file-code-o" aria-hidden="true" />
               &nbsp;Select Blueprint
             </AppLink>


### PR DESCRIPTION
## Current Behavior:
If a user opts not to select a blueprint for a new instance they are able to go to the manager app, which then fails to build the instance because of the 'null' blueprint id. 

## Proposed Behavior:
null checks for blueprint ID and corresponding links to change blueprint or to manager app
If no blueprint is selected a link to the selection view is provided instead of the manager app.
property overview-
![screen shot 2018-10-01 at 10 56 44 am](https://user-images.githubusercontent.com/26661451/46306312-c78d5880-c568-11e8-822a-8e642466678e.png)
instance card-
![screen shot 2018-10-01 at 10 56 28 am](https://user-images.githubusercontent.com/26661451/46306321-cbb97600-c568-11e8-8012-ae7929a29f42.png)
instance row-
![screen shot 2018-10-01 at 11 35 33 am](https://user-images.githubusercontent.com/26661451/46308326-2c977d00-c56e-11e8-9c5e-19e28500d6c8.png)

