### PR TITLE
Add team to instance

### DIFF
--- a/src/apps/properties/src/store/sitesTeams.js
+++ b/src/apps/properties/src/store/sitesTeams.js
@@ -51,11 +51,7 @@ export const addTeamToInstance = (siteZUID, teamZUID, roleZUID) => {
       }
     })
       .then(data => {
-        dispatch({
-          type: 'ADDING_TEAM_TO_INSTANCE_SUCCESS',
-          team: data.data
-        })
-        return data.data
+        return data
       })
       .catch(err => console.error(err))
   }

--- a/src/apps/properties/src/views/PropertyOverview/components/CompanyAccess/CompanyAccess.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/CompanyAccess/CompanyAccess.js
@@ -183,6 +183,14 @@ export default class CompanyAccess extends Component {
     })
   }
   handleAddTeam = () => {
+    if (!this.state.role || !this.state.team) {
+      return this.props.dispatch(
+        notify({
+          type: 'error',
+          message: `You must select a role and a team`
+        })
+      )
+    }
     this.setState({
       submitted: true
     })
@@ -191,28 +199,40 @@ export default class CompanyAccess extends Component {
         addTeamToInstance(this.props.siteZUID, this.state.team, this.state.role)
       )
       .then(data => {
-        this.setState({
-          team: '',
-          role: '',
-          submitted: false
-        })
-        this.props.dispatch(
-          notify({
-            type: 'success',
-            message: 'Team successfully added'
+        if (data && !data.error) {
+          this.setState({
+            team: '',
+            role: '',
+            submitted: false
           })
-        )
-        this.props.dispatch(fetchSiteTeams(this.props.siteZUID))
-        this.props.dispatch(fetchSiteUsers(this.props.siteZUID))
+          this.props.dispatch(
+            notify({
+              type: 'success',
+              message: 'Team successfully added'
+            })
+          )
+          this.props.dispatch(fetchSiteTeams(this.props.siteZUID))
+          this.props.dispatch(fetchSiteUsers(this.props.siteZUID))
+        } else {
+          this.setState({
+            submitted: false
+          })
+          this.props.dispatch(
+            notify({
+              type: 'error',
+              message: `Team failed to add`
+            })
+          )
+        }
       })
-      .catch(() => {
+      .catch(err => {
         this.setState({
           submitted: false
         })
         this.props.dispatch(
           notify({
             type: 'error',
-            message: 'Team failed to add'
+            message: `Team failed to add`
           })
         )
       })

--- a/src/apps/teams/src/components/TeamCard/TeamCard.js
+++ b/src/apps/teams/src/components/TeamCard/TeamCard.js
@@ -448,7 +448,7 @@ export default class TeamCard extends Component {
                   notify({
                     type: 'error',
                     message:
-                      'An error occured canceling this users team invitation'
+                      'An error occurred canceling this users team invitation'
                   })
                 )
               })


### PR DESCRIPTION
## previous behavior
no matter what the response, when a user attempted to add a team to an instance the notification for success was shown. 

## proposed behavior
in cases where there are problems adding a team to an instance, an error is shown to the user