### PR TITLE
Domains ui

### DIFF
--- a/src/apps/properties/src/components/Table/Table.js
+++ b/src/apps/properties/src/components/Table/Table.js
@@ -20,36 +20,43 @@ export const Table = React.memo(function Table(props) {
     )
     setHeaders(headers)
   }
-  const arrangement = props.arrangement.split(' ')
-  const columns = arrangement.reduce((a, b) => {
-    return Number(a) + Number(b)
-  }, 0)
+  const columns = headers.length + (props.actions ? 1 : 0)
 
-  const getWidth = index => `${(100 / columns) * arrangement[index]}%`
+  const getTemplateColumns = () => {
+    let value = ''
+
+    for (let i = 0; i < columns; i++) {
+      value += '1fr '
+    }
+
+    return value
+  }
+
+  const templateColumns = getTemplateColumns()
 
   return (
     <article className={styles.Table}>
-      <header className={styles.TableHeader}>
-        {headers.map((header, index) => (
-          <div className={styles.HeaderItem} style={{ width: getWidth(index) }}>
+      <header
+        className={styles.TableHeader}
+        style={{ gridTemplateColumns: templateColumns }}>
+        {headers.map(header => (
+          <div className={styles.HeaderItem}>
             <span>{header}</span>
           </div>
         ))}
       </header>
       <div className={styles.TableContent}>
         {props.data.map((row, rowIndex) => (
-          <article className={styles.TableRow}>
-            {Object.keys(props.data[0]).map((header, index) => (
-              <p className={styles.Cell} style={{ width: getWidth(index) }}>
+          <article
+            className={styles.TableRow}
+            style={{ gridTemplateColumns: templateColumns }}>
+            {Object.keys(props.data[0]).map(header => (
+              <p className={styles.Cell}>
                 <span>{row[header]}</span>
               </p>
             ))}
             {props.actions && (
-              <p
-                className={styles.RowActions}
-                style={{ width: getWidth(headers.length) }}>
-                {props.actions(rowIndex)}
-              </p>
+              <p className={styles.RowActions}>{props.actions(rowIndex)}</p>
             )}
           </article>
         ))}

--- a/src/apps/properties/src/components/Table/Table.js
+++ b/src/apps/properties/src/components/Table/Table.js
@@ -1,0 +1,59 @@
+import React, { useState, useEffect } from 'react'
+import cx from 'classnames'
+import { Card, CardHeader, CardContent } from '@zesty-io/core/Card'
+
+import styles from './Table.less'
+export const Table = React.memo(function Table(props) {
+  const [headers, setHeaders] = useState([])
+  const [rows, setRows] = useState([])
+  const [modalOpen, setModalOpen] = useState(false)
+
+  useEffect(() => {
+    transformData()
+  }, [])
+
+  const transformData = () => {
+    const headers = Object.keys(props.data[0]).map(header =>
+      header.replace(/([A-Z])/g, ' $1').replace(/^./, function(str) {
+        return str.toUpperCase()
+      })
+    )
+    setHeaders(headers)
+  }
+  const arrangement = props.arrangement.split(' ')
+  const columns = arrangement.reduce((a, b) => {
+    return Number(a) + Number(b)
+  }, 0)
+
+  const getWidth = index => `${(100 / columns) * arrangement[index]}%`
+
+  return (
+    <article className={styles.Table}>
+      <header className={styles.TableHeader}>
+        {headers.map((header, index) => (
+          <div className={styles.HeaderItem} style={{ width: getWidth(index) }}>
+            <span>{header}</span>
+          </div>
+        ))}
+      </header>
+      <div className={styles.TableContent}>
+        {props.data.map((row, rowIndex) => (
+          <article className={styles.TableRow}>
+            {Object.keys(props.data[0]).map((header, index) => (
+              <p className={styles.Cell} style={{ width: getWidth(index) }}>
+                <span>{row[header]}</span>
+              </p>
+            ))}
+            {props.actions && (
+              <p
+                className={styles.RowActions}
+                style={{ width: getWidth(headers.length) }}>
+                {props.actions(rowIndex)}
+              </p>
+            )}
+          </article>
+        ))}
+      </div>
+    </article>
+  )
+})

--- a/src/apps/properties/src/components/Table/Table.js
+++ b/src/apps/properties/src/components/Table/Table.js
@@ -40,7 +40,7 @@ export const Table = React.memo(function Table(props) {
         className={styles.TableHeader}
         style={{ gridTemplateColumns: templateColumns }}>
         {headers.map(header => (
-          <div className={styles.HeaderItem}>
+          <div className={styles.HeaderItem} key={header}>
             <span>{header}</span>
           </div>
         ))}
@@ -48,10 +48,11 @@ export const Table = React.memo(function Table(props) {
       <div className={styles.TableContent}>
         {props.data.map((row, rowIndex) => (
           <article
+            key={row.domain}
             className={styles.TableRow}
             style={{ gridTemplateColumns: templateColumns }}>
             {Object.keys(props.data[0]).map(header => (
-              <p className={styles.Cell}>
+              <p className={styles.Cell} key={row[header]}>
                 <span>{row[header]}</span>
               </p>
             ))}

--- a/src/apps/properties/src/components/Table/Table.less
+++ b/src/apps/properties/src/components/Table/Table.less
@@ -1,0 +1,46 @@
+.Table {
+  margin: 0 0 30px 0;
+
+  .TableHeader {
+    padding: 0;
+    display: flex;
+    width: 100%;
+  }
+
+  .TableContent {
+    width: 100%;
+  }
+
+  .HeaderItem {
+    padding: 5px 20px;
+    font-weight: bold;
+    display: block;
+    text-transform: capitalize;
+    box-sizing: border-box;
+  }
+
+  .LastHeaderItem {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 5px;
+  }
+
+  .TableRow {
+    &:nth-child(odd) {
+      background-color: #eff5ff;
+    }
+  }
+
+  .Cell {
+    color: #8c96ab;
+    padding: 10px 20px;
+    box-sizing: border-box;
+  }
+
+  .RowActions {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+  }
+}

--- a/src/apps/properties/src/components/Table/Table.less
+++ b/src/apps/properties/src/components/Table/Table.less
@@ -1,14 +1,25 @@
 .Table {
   margin: 0 0 30px 0;
+  display: grid;
 
   .TableHeader {
-    padding: 0;
-    display: flex;
-    width: 100%;
+    display: grid;
+    grid-auto-flow: row;
+    grid-gap: 8px;
   }
 
   .TableContent {
     width: 100%;
+
+    .TableRow {
+      display: grid;
+      grid-auto-flow: row;
+      grid-gap: 8px;
+
+      &:nth-child(odd) {
+        background-color: #eff5ff;
+      }
+    }
   }
 
   .HeaderItem {
@@ -17,6 +28,10 @@
     display: block;
     text-transform: capitalize;
     box-sizing: border-box;
+
+    &:first-child {
+      min-width: 250px;
+    }
   }
 
   .LastHeaderItem {
@@ -26,16 +41,15 @@
     padding: 5px;
   }
 
-  .TableRow {
-    &:nth-child(odd) {
-      background-color: #eff5ff;
-    }
-  }
-
   .Cell {
     color: #8c96ab;
     padding: 10px 20px;
     box-sizing: border-box;
+    overflow-wrap: break-word;
+
+    &:first-child {
+      min-width: 250px;
+    }
   }
 
   .RowActions {

--- a/src/apps/properties/src/components/Table/index.js
+++ b/src/apps/properties/src/components/Table/index.js
@@ -1,0 +1,2 @@
+import { Table } from './Table'
+export default Table

--- a/src/apps/properties/src/store/index.js
+++ b/src/apps/properties/src/store/index.js
@@ -5,6 +5,7 @@ import { sitesStats } from './sitesStats'
 import { sitesUsers } from './sitesUsers'
 import { sitesRoles } from './sitesRoles'
 import { sitesCollections } from './sitesCollections'
+import { sitesDomains } from './sitesDomains'
 
 export const properties = {
   sites,
@@ -13,7 +14,8 @@ export const properties = {
   sitesStats,
   sitesUsers,
   sitesRoles,
-  blueprints
+  blueprints,
+  sitesDomains
 }
 
 export const normalizeSites = sites => {

--- a/src/apps/properties/src/store/sites.js
+++ b/src/apps/properties/src/store/sites.js
@@ -24,11 +24,6 @@ export function sites(state = {}, action) {
     case 'SORT_SITES':
       return action.sites
 
-    case 'UPDATE_SITE_DOMAIN':
-      return {
-        ...state,
-        [action.siteZUID]: { ...state[action.siteZUID], domain: action.domain }
-      }
     case 'UPDATE_SITE_BLUEPRINT_SUCCESS':
       return {
         ...state,
@@ -294,28 +289,6 @@ export const sortSites = sortBy => {
         acc[site.ZUID] = site
         return acc
       }, {})
-    })
-  }
-}
-
-export function updateDomain(siteZUID, domain) {
-  return dispatch => {
-    return request(
-      `${CONFIG.API_ACCOUNTS}/instances/${siteZUID}?action=updateDomain`,
-      {
-        method: 'PUT',
-        json: true,
-        body: { domain }
-      }
-    ).then(res => {
-      if (!res.error) {
-        dispatch({
-          type: 'UPDATE_SITE_DOMAIN',
-          domain,
-          siteZUID
-        })
-      }
-      return { domain, ...res }
     })
   }
 }

--- a/src/apps/properties/src/store/sitesDomains.js
+++ b/src/apps/properties/src/store/sitesDomains.js
@@ -1,0 +1,100 @@
+import { request } from '../../../../util/request'
+
+export function sitesDomains(state = {}, action) {
+  switch (action.type) {
+    case 'FETCHING_DOMAINS':
+      return state
+    case 'FETCH_SITE_DOMAINS_SUCCESS':
+      return {
+        ...state,
+        [action.siteZUID]: {
+          ...state[action.siteZUID],
+          domains: action.domains
+        }
+      }
+    case 'FETCH_DOMAINS_ERROR':
+      return state
+    case 'UPDATE_SITE_DOMAINS':
+      return {
+        ...state,
+        [action.siteZUID]: {
+          ...state[action.siteZUID],
+          domains: [...state[action.siteZUID].domains, action.domain]
+        }
+      }
+    case 'REMOVE_SITE_DOMAIN_SUCCESS':
+      const domains = state[action.siteZUID].domains.filter(
+        domain => domain.ZUID !== action.domainZUID
+      )
+      return {
+        ...state,
+        [action.siteZUID]: {
+          ...state[action.siteZUID],
+          domains
+        }
+      }
+    default:
+      return state
+  }
+}
+
+export function fetchDomains(siteZUID) {
+  return (dispatch, getState) => {
+    const state = getState()
+    return request(`${CONFIG.API_ACCOUNTS}/instances/${siteZUID}/domains`, {
+      method: 'Get',
+      json: true
+    }).then(res => {
+      const domains = res.data.map(item => ({
+        ZUID: item.ZUID,
+        domain: item.domain,
+        branch: item.branch,
+        createdAt: item.createdAt
+      }))
+
+      if (!res.error) {
+        dispatch({
+          type: 'FETCH_SITE_DOMAINS_SUCCESS',
+          domains,
+          siteZUID
+        })
+      }
+      return res.data
+    })
+  }
+}
+
+export function addDomain(siteZUID, domain, branch) {
+  return dispatch => {
+    return request(`${CONFIG.API_ACCOUNTS}/instances/${siteZUID}/domains`, {
+      method: 'POST',
+      json: true,
+      body: { domain, branch }
+    }).then(res => {
+      if (!res.error) {
+        dispatch({
+          type: 'UPDATE_SITE_DOMAINS',
+          domain: res.data,
+          siteZUID
+        })
+      }
+      return res.data
+    })
+  }
+}
+
+export const removeDomain = (siteZUID, domainZUID) => {
+  return dispatch => {
+    return request(
+      `${CONFIG.API_ACCOUNTS}/instances/${siteZUID}/domains/${domainZUID}`,
+      { method: 'DELETE' }
+    ).then(res => {
+      dispatch({
+        type: 'REMOVE_SITE_DOMAIN_SUCCESS',
+        domainZUID,
+        siteZUID
+      })
+      return res.data
+    })
+  }
+}

--- a/src/apps/properties/src/views/PropertiesList/PropertiesList.js
+++ b/src/apps/properties/src/views/PropertiesList/PropertiesList.js
@@ -17,17 +17,18 @@ export default connect((state, props) => {
   // set the search string end ecosystem from the settings object
   const searchString =
     state.settings.filter && state.settings.filter.toLowerCase()
-  const eco = state.settings.eco
 
+  const eco = state.settings.eco
   const sites = state.sites
 
   let filtered = {}
   let ecosystem = {}
+
   // filter by ecosystem if eco is present
   if (eco) {
     for (const zuid in sites) {
       let site = sites[zuid]
-      if (site.ecoID && site.ecoID == eco) {
+      if (site && site.ecoZUID === eco) {
         ecosystem[zuid] = site
       }
     }
@@ -36,6 +37,7 @@ export default connect((state, props) => {
       filtered = ecosystem
     }
   }
+
   // filter sites if searchString is present
   if (searchString) {
     let instances = eco ? ecosystem : sites

--- a/src/apps/properties/src/views/PropertiesList/components/PropertiesHeader/PropertiesHeader.js
+++ b/src/apps/properties/src/views/PropertiesList/components/PropertiesHeader/PropertiesHeader.js
@@ -35,20 +35,12 @@ export default connect(state => state)(
       })
     }, 250)
 
-    filterByEco = (name, value) => {
-      if (value) {
-        this.setState({ eco: value })
-        this.props.dispatch({
-          type: 'SETTING_ECO',
-          eco: Number(value)
-        })
-      } else {
-        this.setState({ eco: false })
-        this.props.dispatch({
-          type: 'SETTING_ECO',
-          eco: ''
-        })
-      }
+    filterByEco = (name, eco) => {
+      this.setState({ eco })
+      this.props.dispatch({
+        type: 'SETTING_ECO',
+        eco
+      })
     }
 
     sort = by => {
@@ -58,7 +50,7 @@ export default connect(state => state)(
     render() {
       const ecosystems = this.props.ecosystems.map(eco => {
         return {
-          value: eco.orgID,
+          value: eco.ZUID,
           text: eco.name
         }
       })
@@ -71,7 +63,7 @@ export default connect(state => state)(
                 className={styles.Ecosystem}
                 name="ecoFilter"
                 onChange={this.filterByEco}
-                selection={ecosystems.find(eco => eco.id == this.state.eco)}
+                selection={ecosystems.find(eco => eco.ZUID == this.state.eco)}
                 options={ecosystems}
               />
             ) : null}

--- a/src/apps/properties/src/views/PropertiesList/components/PropertiesHeader/PropertiesHeader.js
+++ b/src/apps/properties/src/views/PropertiesList/components/PropertiesHeader/PropertiesHeader.js
@@ -35,7 +35,9 @@ export default connect(state => state)(
       })
     }, 250)
 
-    filterByEco = (name, eco) => {
+    filterByEco = (name, value) => {
+      let eco = value && value !== '0' ? value : false
+
       this.setState({ eco })
       this.props.dispatch({
         type: 'SETTING_ECO',

--- a/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
+++ b/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
@@ -51,14 +51,16 @@ class PropertyOverview extends Component {
     }
   }
 
-  renderDomainUI = routeProps => {
-    const customDomains = this.props.domains.filter(item => {
-      const domainParts = item.domain.split('.')
-      const customDomain = domainParts
-        .slice(Math.max(domainParts.length - 2, 0))
-        .join('.')
-      return customDomain !== 'zesty.dev'
-    })
+  renderDomainsUI = routeProps => {
+    const customDomains =
+      this.props.domains &&
+      this.props.domains.filter(item => {
+        const domainParts = item.domain.split('.')
+        const customDomain = domainParts
+          .slice(Math.max(domainParts.length - 2, 0))
+          .join('.')
+        return customDomain !== 'zesty.dev'
+      })
     return customDomains && customDomains.length > 0 ? (
       <Meta
         {...routeProps}
@@ -123,13 +125,13 @@ class PropertyOverview extends Component {
             message="Checking Instance Permissions">
             <Route
               path="/instances/:siteZUID/launch"
-              render={routeProps => this.renderDomainUI(routeProps)}
+              render={routeProps => this.renderDomainsUI(routeProps)}
             />
 
             <Route
               path="/instances/:siteZUID"
               exact
-              render={routeProps => this.renderDomainUI(routeProps)}
+              render={routeProps => this.renderDomainsUI(routeProps)}
             />
 
             <Route

--- a/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
+++ b/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
@@ -18,6 +18,8 @@ import { fetchSiteUsers, fetchSiteUsersPending } from '../../store/sitesUsers'
 import { fetchSiteRoles } from '../../store/sitesRoles'
 import { fetchSiteTeams } from '../../store/sitesTeams'
 import { fetchBlueprint } from '../../store/blueprints'
+import { fetchDomains } from '../../store/sitesDomains'
+
 // import { fetchSite } from '../../store/sites'
 // import { updateSite } from '../../store/sites'
 import { notify } from '../../../../../shell/store/notifications'
@@ -36,7 +38,8 @@ class PropertyOverview extends Component {
       loadingUsersPending: true,
       loadingTeams: true,
       loadingCollections: true,
-      loadingBlueprint: true
+      loadingBlueprint: true,
+      loadingDomains: true
     }
   }
   componentDidMount() {
@@ -86,7 +89,8 @@ class PropertyOverview extends Component {
               !this.state.loadingRoles &&
               !this.state.loadingTeams &&
               !this.state.loadingUsers &&
-              !this.state.loadingBlueprint
+              !this.state.loadingBlueprint &&
+              !this.state.loadingDomains
             }
             message="Checking Instance Permissions">
             <Route
@@ -112,6 +116,7 @@ class PropertyOverview extends Component {
                     isAdmin={this.props.isAdmin}
                     dispatch={this.props.dispatch}
                     site={this.props.site}
+                    domains={this.props.domains}
                   />
                 )
               }}
@@ -199,8 +204,21 @@ class PropertyOverview extends Component {
       loadingUsersPending: true,
       loadingTeams: true,
       loadingCollections: true,
-      loadingBlueprint: true
+      loadingBlueprint: true,
+      loadingDomains: true
     })
+    props
+      .dispatch(fetchSiteUsers(props.siteZUID))
+      .then(() => {
+        this.setState({
+          loadingUsers: false
+        })
+      })
+      .catch(() => {
+        this.props.dispatch(
+          notify({ message: 'Error fetching users', type: 'error' })
+        )
+      })
     props
       .dispatch(fetchSiteUsers(props.siteZUID))
       .then(() => {
@@ -247,6 +265,19 @@ class PropertyOverview extends Component {
       .catch(() => {
         this.props.dispatch(
           notify({ message: 'Error fetching teams', type: 'error' })
+        )
+      })
+    props
+      .dispatch(fetchDomains(props.siteZUID))
+      .then(() => {
+        this.setState({
+          loadingDomains: false
+        })
+      })
+      .catch(e => {
+        console.log('e', e)
+        this.props.dispatch(
+          notify({ message: 'Error fetching domains', type: 'error' })
         )
       })
     // validity check blueprint ID before fetching
@@ -321,6 +352,9 @@ export default connect((state, props) => {
     teams: state.sitesTeams[siteZUID] || {},
     blueprint: state.sites[siteZUID]
       ? state.blueprints[state.sites[siteZUID].blueprintID] || {}
+      : {},
+    domains: state.sitesDomains[siteZUID]
+      ? state.sitesDomains[siteZUID].domains
       : {}
   }
 })(PropertyOverview)

--- a/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
+++ b/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
@@ -50,6 +50,34 @@ class PropertyOverview extends Component {
       this.fetchSiteData(this.props)
     }
   }
+
+  renderDomainUI = routeProps => {
+    const customDomains = this.props.domains.filter(item => {
+      const domainParts = item.domain.split('.')
+      const customDomain = domainParts
+        .slice(Math.max(domainParts.length - 2, 0))
+        .join('.')
+      return customDomain !== 'zesty.dev'
+    })
+    return customDomains && customDomains.length > 0 ? (
+      <Meta
+        {...routeProps}
+        isAdmin={this.props.isAdmin}
+        dispatch={this.props.dispatch}
+        site={this.props.site}
+        domains={this.props.domains}
+        customDomains={customDomains}
+      />
+    ) : (
+      <LaunchWizard
+        {...routeProps}
+        isAdmin={this.props.isAdmin}
+        dispatch={this.props.dispatch}
+        site={this.props.site}
+      />
+    )
+  }
+
   render() {
     document.title = `Accounts: ${this.props.site.name}`
     return (
@@ -95,31 +123,13 @@ class PropertyOverview extends Component {
             message="Checking Instance Permissions">
             <Route
               path="/instances/:siteZUID/launch"
-              render={routeProps => {
-                return (
-                  <LaunchWizard
-                    {...routeProps}
-                    isAdmin={this.props.isAdmin}
-                    dispatch={this.props.dispatch}
-                    site={this.props.site}
-                  />
-                )
-              }}
+              render={routeProps => this.renderDomainUI(routeProps)}
             />
 
             <Route
               path="/instances/:siteZUID"
-              render={routeProps => {
-                return (
-                  <Meta
-                    {...routeProps}
-                    isAdmin={this.props.isAdmin}
-                    dispatch={this.props.dispatch}
-                    site={this.props.site}
-                    domains={this.props.domains}
-                  />
-                )
-              }}
+              exact
+              render={routeProps => this.renderDomainUI(routeProps)}
             />
 
             <Route

--- a/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
+++ b/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
@@ -39,19 +39,21 @@ class PropertyOverview extends Component {
       loadingTeams: true,
       loadingCollections: true,
       loadingBlueprint: true,
-      loadingDomains: true
+      loadingDomains: true,
+      customDomains: []
     }
   }
   componentDidMount() {
     this.fetchSiteData(this.props)
   }
+
   componentDidUpdate(prevProps) {
     if (this.props.siteZUID !== prevProps.siteZUID) {
       this.fetchSiteData(this.props)
     }
   }
 
-  renderDomainsUI = routeProps => {
+  getCustomDomains = routeProps => {
     const customDomains =
       this.props.domains &&
       this.props.domains.filter(item => {
@@ -61,23 +63,7 @@ class PropertyOverview extends Component {
           .join('.')
         return customDomain !== 'zesty.dev'
       })
-    return customDomains && customDomains.length > 0 ? (
-      <Meta
-        {...routeProps}
-        isAdmin={this.props.isAdmin}
-        dispatch={this.props.dispatch}
-        site={this.props.site}
-        domains={this.props.domains}
-        customDomains={customDomains}
-      />
-    ) : (
-      <LaunchWizard
-        {...routeProps}
-        isAdmin={this.props.isAdmin}
-        dispatch={this.props.dispatch}
-        site={this.props.site}
-      />
-    )
+    return customDomains
   }
 
   render() {
@@ -125,13 +111,54 @@ class PropertyOverview extends Component {
             message="Checking Instance Permissions">
             <Route
               path="/instances/:siteZUID/launch"
-              render={routeProps => this.renderDomainsUI(routeProps)}
+              render={routeProps => {
+                const customDomains = this.getCustomDomains(routeProps)
+                return (
+                  <>
+                    <LaunchWizard
+                      {...routeProps}
+                      isAdmin={this.props.isAdmin}
+                      dispatch={this.props.dispatch}
+                      site={this.props.site}
+                    />
+                    {customDomains && customDomains.length > 0 && (
+                      <Meta
+                        {...routeProps}
+                        isAdmin={this.props.isAdmin}
+                        dispatch={this.props.dispatch}
+                        site={this.props.site}
+                        domains={this.props.domains}
+                        customDomains={customDomains}
+                      />
+                    )}
+                  </>
+                )
+              }}
             />
 
             <Route
               path="/instances/:siteZUID"
               exact
-              render={routeProps => this.renderDomainsUI(routeProps)}
+              render={routeProps => {
+                const customDomains = this.getCustomDomains(routeProps)
+                return customDomains && customDomains.length > 0 ? (
+                  <Meta
+                    {...routeProps}
+                    isAdmin={this.props.isAdmin}
+                    dispatch={this.props.dispatch}
+                    site={this.props.site}
+                    domains={this.props.domains}
+                    customDomains={customDomains}
+                  />
+                ) : (
+                  <LaunchWizard
+                    {...routeProps}
+                    isAdmin={this.props.isAdmin}
+                    dispatch={this.props.dispatch}
+                    site={this.props.site}
+                  />
+                )
+              }}
             />
 
             <Route

--- a/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
@@ -1,10 +1,11 @@
 import React, { Component } from 'react'
 
-import { updateDomain } from '../../../../store/sites'
+import { addDomain } from '../../../../store/sitesDomains'
 import { notify } from '../../../../../../../shell/store/notifications'
 
 import { Input } from '@zesty-io/core/Input'
 import { Button } from '@zesty-io/core/Button'
+import { DropDownFieldType } from '@zesty-io/core/DropDownFieldType'
 
 import styles from './Domain.less'
 export default class Domain extends Component {
@@ -18,36 +19,17 @@ export default class Domain extends Component {
     super(props)
     this.state = {
       submitted: false,
-      domain: props.domain || ''
+      domain: null,
+      domainBranch: 'dev'
     }
+    this.branches = [
+      { value: 'dev', text: 'dev' },
+      { value: 'live', text: 'live' }
+    ]
   }
-  render() {
-    return (
-      <label className={styles.Domain}>
-        <span className={styles.Edit}>
-          <Input
-            name="domain"
-            placeholder="Set a custom domain"
-            value={this.state.domain}
-            onChange={evt => {
-              this.setState({
-                domain: evt.target.value
-              })
-            }}
-          />
-          <Button
-            data-test="saveDomain"
-            kind="save"
-            disabled={
-              this.props.domain === this.state.domain || this.state.submitted
-            }
-            onClick={this.handleSave}>
-            <i className="fas fa-save" aria-hidden="true" />
-            Save
-          </Button>
-        </span>
-      </label>
-    )
+
+  selectBranch = (name, value) => {
+    this.setState({ domainBranch: value })
   }
 
   handleSave = () => {
@@ -61,7 +43,9 @@ export default class Domain extends Component {
     }
 
     this.props
-      .dispatch(updateDomain(this.props.siteZUID, strippedDomain))
+      .dispatch(
+        addDomain(this.props.siteZUID, strippedDomain, this.state.domainBranch)
+      )
       .then(({ error, domain }) => {
         this.setState({
           domain,
@@ -83,5 +67,44 @@ export default class Domain extends Component {
           })
         )
       })
+  }
+
+  render() {
+    return (
+      <label className={styles.Domain}>
+        <div className={styles.DomainInput}>
+          <Input
+            name="domain"
+            placeholder="Set a custom domain"
+            value={this.state.domain}
+            onChange={evt => {
+              this.setState({
+                domain: evt.target.value
+              })
+            }}
+          />
+        </div>
+        {this.props.customDomains && this.props.customDomains.length > 0 && (
+          <DropDownFieldType
+            name="branch"
+            onChange={this.selectBranch}
+            selection={this.branches.filter(
+              branch => branch.value === this.state.domainBranch
+            )}
+            options={this.branches}
+          />
+        )}
+        <Button
+          className={styles.Button}
+          data-test="saveDomain"
+          disabled={
+            this.props.domain === this.state.domain || this.state.submitted
+          }
+          onClick={this.handleSave}>
+          <i className="fa fa-plus" aria-hidden="true" />
+          Add domain
+        </Button>
+      </label>
+    )
   }
 }

--- a/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
@@ -20,7 +20,7 @@ export default class Domain extends Component {
     this.state = {
       submitted: false,
       domain: null,
-      domainBranch: 'dev'
+      domainBranch: 'live'
     }
     this.branches = [
       { value: 'dev', text: 'dev' },
@@ -48,7 +48,7 @@ export default class Domain extends Component {
       )
       .then(({ error, domain }) => {
         this.setState({
-          domain,
+          domain: null,
           submitted: false
         })
         this.props.dispatch(

--- a/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.less
+++ b/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.less
@@ -1,6 +1,19 @@
 .Domain {
-  display: flex;
   align-items: center;
+  display: grid;
+  grid-auto-flow: row;
+  grid-template-columns: 1fr 1fr 135px;
+  grid-gap: 8px;
+  padding: 16px 0;
+  width: 100%;
+
+  .DomainInput {
+    input {
+      display: block;
+      width: 100%;
+    }
+  }
+
   .Name {
     cursor: pointer;
     i {
@@ -21,5 +34,13 @@
       margin-right: 8px;
       width: 300px;
     }
+  }
+
+  .Dropdown {
+    width: 300px;
+  }
+
+  .Button {
+    width: 135px;
   }
 }

--- a/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.js
@@ -1,11 +1,21 @@
-import React, { PureComponent } from 'react'
-import PropertyName from '../PropertyName'
+import React, { Component, useState } from 'react'
+import { connect } from 'react-redux'
 import Domain from '../Domain'
+import { addDomain, removeDomain } from '../../../../store/sitesDomains'
+import { notify } from '../../../../../../../shell/store/notifications'
 
+import PropertyName from '../PropertyName'
+import Table from '../../../../components/Table'
 import { Card, CardHeader, CardContent, CardFooter } from '@zesty-io/core/Card'
+import { Modal, ModalContent, ModalFooter } from '@zesty-io/core/Modal'
+import { Input } from '@zesty-io/core/Input'
 import { Url } from '@zesty-io/core/Url'
+import { Button } from '@zesty-io/core/Button'
+import { Infotip } from '@zesty-io/core/Infotip'
+import { DropDownFieldType } from '@zesty-io/core/DropDownFieldType'
 
 import styles from './Meta.less'
+
 const formatDate = date => {
   if (!date) {
     return ''
@@ -15,78 +25,273 @@ const formatDate = date => {
     1}-${newDate.getDate()}-${newDate.getFullYear()}`
 }
 
-export default class Meta extends PureComponent {
-  render() {
+export default class Meta extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      domain: null,
+      openModal: false,
+      submitted: false,
+      openRemoveModal: false,
+      domainToDelete: null,
+      domainBranch: 'dev'
+    }
+  }
+
+  setModalOpen = openModal => {
+    this.setState({ openModal })
+  }
+
+  setRemoveModalOpen = openRemoveModal => {
+    this.setState({ openRemoveModal })
+  }
+
+  handleSave = () => {
+    this.setState({ submitted: true })
+
+    let strippedDomain = ''
+    if (this.state.domain) {
+      strippedDomain = this.state.domain
+        .toLowerCase()
+        .replace(/http:\/\/|https:\/\//g, '')
+    }
+    this.props
+      .dispatch(
+        addDomain(this.props.site.ZUID, strippedDomain, this.state.domainBranch)
+      )
+      .then(() => {
+        this.setState({
+          submitted: false,
+          openModal: false,
+          domain: null
+        })
+        this.props.dispatch(
+          notify({
+            message: `Your domain has been added`,
+            type: 'success'
+          })
+        )
+      })
+      .catch(data => {
+        this.setState({ submitted: false })
+        this.props.dispatch(
+          notify({
+            message: data.error,
+            type: 'error'
+          })
+        )
+      })
+  }
+
+  handleRemove = () => {
+    if (this.state.domainToDelete) {
+      this.props
+        .dispatch(removeDomain(this.props.site.ZUID, this.state.domainToDelete))
+        .then(({ error, domain }) => {
+          this.props.dispatch(
+            notify({
+              message: `Your domain has been removed`,
+              type: 'success'
+            })
+          )
+          this.setState({ domainToDelete: null, openRemoveModal: false })
+        })
+        .catch(data => {
+          this.setState({ submitted: false })
+          this.props.dispatch(
+            notify({
+              message: data.error,
+              type: 'error'
+            })
+          )
+        })
+    }
+  }
+
+  handleConfirmDelete = domainZUID => {
+    this.setState({ domainToDelete: domainZUID })
+    this.setRemoveModalOpen(true)
+  }
+
+  renderDomainsActions = index => {
+    const domainZUID = this.props.domains[index].ZUID
     return (
-      <Card className={styles.Meta}>
-        <CardHeader className={styles.CardHeader}>
-          <h2>
-            <i className="fa fa-info-circle" aria-hidden="true" />
-            &nbsp;
-            <PropertyName
-              siteZUID={this.props.site.ZUID}
-              name={this.props.site.name}
-              dispatch={this.props.dispatch}
-            />
-          </h2>
-        </CardHeader>
-        <CardContent className={styles.CardContent}>
-          <p className={styles.domain}>
-            <span className={styles.title}>Domain:&nbsp;</span>
-            {this.props.isAdmin ? (
-              <Domain
-                domain={this.props.site.domain}
+      <Button
+        kind="warn"
+        className={styles.delete}
+        onClick={() => this.handleConfirmDelete(domainZUID)}>
+        <i className="fas fa-trash" />
+      </Button>
+    )
+  }
+
+  selectBranch = (name, value) => {
+    this.setState({ domainBranch: value })
+  }
+
+  render() {
+    const domainsTable = this.props.domains.map(domainData => {
+      const { domain, branch, createdAt } = domainData
+      return {
+        domain,
+        branch,
+        createdAt: formatDate(createdAt)
+      }
+    })
+
+    const branches = [
+      { value: 'dev', text: 'dev' },
+      { value: 'live', text: 'live' }
+    ]
+    return (
+      <>
+        <Card className={styles.Meta}>
+          <CardHeader className={styles.CardHeader}>
+            <h2>
+              <i className="fa fa-info-circle" aria-hidden="true" />
+              &nbsp;
+              <PropertyName
                 siteZUID={this.props.site.ZUID}
+                name={this.props.site.name}
                 dispatch={this.props.dispatch}
               />
-            ) : this.props.site.domain ? (
-              this.props.site.domain
+            </h2>
+          </CardHeader>
+          <CardContent className={styles.CardContent}>
+            <div className={styles.TableAction}>
+              <h3>Domains</h3>
+              <Button onClick={() => this.setModalOpen(true)}>
+                Add domain
+              </Button>
+            </div>
+            {this.props.domains ? (
+              <Table
+                arrangement="3 1 1 1"
+                data={domainsTable}
+                siteZUID={this.props.site.ZUID}
+                dispatch={this.props.dispatch}
+                isAdmin={this.props.isAdmin}
+                actions={this.renderDomainsActions}
+              />
             ) : (
               <em>Ask your instance owner to set a domain</em>
             )}
-          </p>
 
-          <article>
-            <p className={styles.setting}>
-              <span className={styles.title}>Created On:</span>{' '}
-              <span className={styles.NonEditable}>
-                {formatDate(this.props.site.createdAt)}
-              </span>
-            </p>
-            <p className={styles.setting}>
-              <span className={styles.title}>Updated On:</span>{' '}
-              <span className={styles.NonEditable}>
-                {formatDate(this.props.site.updatedAt)}
-              </span>
-            </p>
-            <p className={styles.setting}>
-              <span className={styles.title}>Instance ZUID:</span>{' '}
-              <span className={styles.NonEditable}>{this.props.site.ZUID}</span>
-            </p>
-            <p className={styles.setting}>
-              <span className={styles.title}>
-                Numeric ID <small>(Legacy)</small>:
-              </span>
-              <span className={styles.NonEditable}>{this.props.site.ID}</span>
-            </p>
-            <p className={styles.setting}>
-              <span className={styles.title}>
-                Hash ID <small>(Legacy)</small>:
-              </span>
-              <span className={styles.NonEditable}>
-                {this.props.site.randomHashID}
-              </span>
-            </p>
-          </article>
-          <Url
-            className={styles.manager}
-            target="_blank"
-            href={`${CONFIG.MANAGER_URL_PROTOCOL}${this.props.site.randomHashID}${CONFIG.MANAGER_URL}/#!/settings/instance/general`}>
-            <i className="fa fa-external-link" aria-hidden="true" />
-            &nbsp;Open Instance Settings
-          </Url>
-        </CardContent>
-      </Card>
+            <article>
+              <p className={styles.setting}>
+                <span className={styles.title}>Created On:</span>{' '}
+                <span className={styles.NonEditable}>
+                  {formatDate(this.props.site.createdAt)}
+                </span>
+              </p>
+              <p className={styles.setting}>
+                <span className={styles.title}>Updated On:</span>{' '}
+                <span className={styles.NonEditable}>
+                  {formatDate(this.props.site.updatedAt)}
+                </span>
+              </p>
+              <p className={styles.setting}>
+                <span className={styles.title}>Instance ZUID:</span>{' '}
+                <span className={styles.NonEditable}>
+                  {this.props.site.ZUID}
+                </span>
+              </p>
+              <p className={styles.setting}>
+                <span className={styles.title}>
+                  Numeric ID <small>(Legacy)</small>:
+                </span>
+                <span className={styles.NonEditable}>{this.props.site.ID}</span>
+              </p>
+              <p className={styles.setting}>
+                <span className={styles.title}>
+                  Hash ID <small>(Legacy)</small>:
+                </span>
+                <span className={styles.NonEditable}>
+                  {this.props.site.randomHashID}
+                </span>
+              </p>
+            </article>
+            <Url
+              className={styles.manager}
+              target="_blank"
+              href={`${CONFIG.MANAGER_URL_PROTOCOL}${this.props.site.randomHashID}${CONFIG.MANAGER_URL}/#!/settings/instance/general`}>
+              <i className="fa fa-external-link" aria-hidden="true" />
+              &nbsp;Open Instance Settings
+            </Url>
+          </CardContent>
+        </Card>
+        {this.state.openModal && (
+          <Modal onClose={() => this.setModalOpen(false)}>
+            <ModalContent className={styles.ModalContent}>
+              <h2 className={styles.ModalTitle}>Add a new domain</h2>
+              <div className={styles.Form}>
+                <div className={styles.FieldGroup}>
+                  <span className={styles.title}>Domain</span>{' '}
+                  <Input
+                    className={styles.Field}
+                    name="domain"
+                    placeholder="Set a custom domain"
+                    value={this.state.domain}
+                    onChange={evt => {
+                      this.setState({
+                        domain: evt.target.value
+                      })
+                    }}
+                  />
+                </div>
+                <div className={styles.FieldGroup}>
+                  <span className={styles.title}>Branch</span>{' '}
+                  <DropDownFieldType
+                    name="branch"
+                    onChange={this.selectBranch}
+                    selection={branches.filter(
+                      branch => branch.value === this.state.domainBranch
+                    )}
+                    options={branches}
+                  />
+                </div>
+              </div>
+            </ModalContent>
+            <ModalFooter className={styles.ModalFooter}>
+              <Button kind="cancel" onClick={() => this.setModalOpen(false)}>
+                <i className="fas fa-ban"></i>Cancel (ESC)
+              </Button>
+              <Button
+                data-test="saveDomain"
+                kind="save"
+                disabled={
+                  this.props.domain === this.state.domain ||
+                  this.state.submitted
+                }
+                onClick={this.handleSave}>
+                <i className="fas fa-save" aria-hidden="true" />
+                Save
+              </Button>
+            </ModalFooter>
+          </Modal>
+        )}
+        {this.state.openRemoveModal && (
+          <Modal onClose={() => this.setRemoveModalOpen(false)}>
+            <ModalContent className={styles.ModalContent}>
+              <h2>Are you sure you want to remove your domain?</h2>
+            </ModalContent>
+            <ModalFooter className={styles.ModalFooter}>
+              <Button
+                kind="cancel"
+                onClick={() => this.setRemoveModalOpen(false)}>
+                <i className="fas fa-ban"></i>Cancel (ESC)
+              </Button>
+              <Button
+                data-test="saveDomain"
+                kind="warn"
+                onClick={this.handleRemove}>
+                <i className="fas fa-trash" aria-hidden="true" />
+                Remove
+              </Button>
+            </ModalFooter>
+          </Modal>
+        )}
+      </>
     )
   }
 }

--- a/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.js
@@ -105,13 +105,26 @@ export default class Meta extends Component {
           </CardHeader>
           <CardContent className={styles.CardContent}>
             <div className={styles.TableAction}>
-              <Domain
-                siteZUID={this.props.site.ZUID}
-                site={this.props.site}
-                dispatch={this.props.dispatch}
-                domain={this.props.domains}
-                customDomains={this.props.customDomains}
-              />
+              {this.props.isAdmin ? (
+                <Domain
+                  siteZUID={this.props.site.ZUID}
+                  site={this.props.site}
+                  dispatch={this.props.dispatch}
+                  domain={this.props.domains}
+                  customDomains={this.props.customDomains}
+                />
+              ) : (
+                <p className={styles.domain}>
+                  <em>
+                    <i
+                      className="fa fa-exclamation-triangle"
+                      aria-hidden="true"
+                    />
+                    &nbsp; You must be a instance owner or admin to set the
+                    domain
+                  </em>
+                </p>
+              )}
             </div>
             {this.props.domains ? (
               <Table

--- a/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.js
@@ -1,18 +1,15 @@
 import React, { Component, useState } from 'react'
 import { connect } from 'react-redux'
 import Domain from '../Domain'
-import { addDomain, removeDomain } from '../../../../store/sitesDomains'
+import { removeDomain } from '../../../../store/sitesDomains'
 import { notify } from '../../../../../../../shell/store/notifications'
 
 import PropertyName from '../PropertyName'
 import Table from '../../../../components/Table'
 import { Card, CardHeader, CardContent, CardFooter } from '@zesty-io/core/Card'
 import { Modal, ModalContent, ModalFooter } from '@zesty-io/core/Modal'
-import { Input } from '@zesty-io/core/Input'
 import { Url } from '@zesty-io/core/Url'
 import { Button } from '@zesty-io/core/Button'
-import { Infotip } from '@zesty-io/core/Infotip'
-import { DropDownFieldType } from '@zesty-io/core/DropDownFieldType'
 
 import styles from './Meta.less'
 
@@ -29,58 +26,13 @@ export default class Meta extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      domain: null,
-      openModal: false,
-      submitted: false,
       openRemoveModal: false,
-      domainToDelete: null,
-      domainBranch: 'dev'
+      domainToDelete: null
     }
-  }
-
-  setModalOpen = openModal => {
-    this.setState({ openModal })
   }
 
   setRemoveModalOpen = openRemoveModal => {
     this.setState({ openRemoveModal })
-  }
-
-  handleSave = () => {
-    this.setState({ submitted: true })
-
-    let strippedDomain = ''
-    if (this.state.domain) {
-      strippedDomain = this.state.domain
-        .toLowerCase()
-        .replace(/http:\/\/|https:\/\//g, '')
-    }
-    this.props
-      .dispatch(
-        addDomain(this.props.site.ZUID, strippedDomain, this.state.domainBranch)
-      )
-      .then(() => {
-        this.setState({
-          submitted: false,
-          openModal: false,
-          domain: null
-        })
-        this.props.dispatch(
-          notify({
-            message: `Your domain has been added`,
-            type: 'success'
-          })
-        )
-      })
-      .catch(data => {
-        this.setState({ submitted: false })
-        this.props.dispatch(
-          notify({
-            message: data.error,
-            type: 'error'
-          })
-        )
-      })
   }
 
   handleRemove = () => {
@@ -125,24 +77,18 @@ export default class Meta extends Component {
     )
   }
 
-  selectBranch = (name, value) => {
-    this.setState({ domainBranch: value })
-  }
-
   render() {
-    const domainsTable = this.props.domains.map(domainData => {
-      const { domain, branch, createdAt } = domainData
-      return {
-        domain,
-        branch,
-        createdAt: formatDate(createdAt)
-      }
-    })
+    const domainsTable =
+      this.props.domains &&
+      this.props.domains.map(domainData => {
+        const { domain, branch, createdAt } = domainData
+        return {
+          domain,
+          branch,
+          createdAt: formatDate(createdAt)
+        }
+      })
 
-    const branches = [
-      { value: 'dev', text: 'dev' },
-      { value: 'live', text: 'live' }
-    ]
     return (
       <>
         <Card className={styles.Meta}>
@@ -159,10 +105,13 @@ export default class Meta extends Component {
           </CardHeader>
           <CardContent className={styles.CardContent}>
             <div className={styles.TableAction}>
-              <h3>Domains</h3>
-              <Button onClick={() => this.setModalOpen(true)}>
-                Add domain
-              </Button>
+              <Domain
+                siteZUID={this.props.site.ZUID}
+                site={this.props.site}
+                dispatch={this.props.dispatch}
+                domain={this.props.domains}
+                customDomains={this.props.customDomains}
+              />
             </div>
             {this.props.domains ? (
               <Table
@@ -220,58 +169,10 @@ export default class Meta extends Component {
             </Url>
           </CardContent>
         </Card>
-        {this.state.openModal && (
-          <Modal onClose={() => this.setModalOpen(false)}>
-            <ModalContent className={styles.ModalContent}>
-              <h2 className={styles.ModalTitle}>Add a new domain</h2>
-              <div className={styles.Form}>
-                <div className={styles.FieldGroup}>
-                  <span className={styles.title}>Domain</span>{' '}
-                  <Input
-                    className={styles.Field}
-                    name="domain"
-                    placeholder="Set a custom domain"
-                    value={this.state.domain}
-                    onChange={evt => {
-                      this.setState({
-                        domain: evt.target.value
-                      })
-                    }}
-                  />
-                </div>
-                <div className={styles.FieldGroup}>
-                  <span className={styles.title}>Branch</span>{' '}
-                  <DropDownFieldType
-                    name="branch"
-                    onChange={this.selectBranch}
-                    selection={branches.filter(
-                      branch => branch.value === this.state.domainBranch
-                    )}
-                    options={branches}
-                  />
-                </div>
-              </div>
-            </ModalContent>
-            <ModalFooter className={styles.ModalFooter}>
-              <Button kind="cancel" onClick={() => this.setModalOpen(false)}>
-                <i className="fas fa-ban"></i>Cancel (ESC)
-              </Button>
-              <Button
-                data-test="saveDomain"
-                kind="save"
-                disabled={
-                  this.props.domain === this.state.domain ||
-                  this.state.submitted
-                }
-                onClick={this.handleSave}>
-                <i className="fas fa-save" aria-hidden="true" />
-                Save
-              </Button>
-            </ModalFooter>
-          </Modal>
-        )}
         {this.state.openRemoveModal && (
-          <Modal onClose={() => this.setRemoveModalOpen(false)}>
+          <Modal
+            className={styles.Modal}
+            onClose={() => this.setRemoveModalOpen(false)}>
             <ModalContent className={styles.ModalContent}>
               <h2>Are you sure you want to remove your domain?</h2>
             </ModalContent>

--- a/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.less
+++ b/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.less
@@ -8,6 +8,12 @@
       align-items: center;
     }
   }
+  .TableAction {
+    display: flex;
+    justify-content: space-between;
+    margin: 0.5em 0 2em;
+    align-items: center;
+  }
   .CardContent {
     .domain {
       margin: 1rem 0;
@@ -36,5 +42,27 @@
     .manager {
       margin: 0;
     }
+  }
+}
+
+.ModalTitle {
+  margin-bottom: 1em;
+}
+
+.ModalFooter {
+  display: flex;
+  justify-content: space-between;
+}
+
+.Form {
+  display: flex;
+  justify-content: space-between;
+
+  .FieldGroup {
+    width: 45%;
+  }
+
+  .Field {
+    width: 100%;
   }
 }

--- a/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.less
+++ b/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.less
@@ -45,24 +45,12 @@
   }
 }
 
-.ModalTitle {
-  margin-bottom: 1em;
+.Modal {
+  max-width: 200px;
 }
 
 .ModalFooter {
+  margin-top: 1em;
   display: flex;
   justify-content: space-between;
-}
-
-.Form {
-  display: flex;
-  justify-content: space-between;
-
-  .FieldGroup {
-    width: 45%;
-  }
-
-  .Field {
-    width: 100%;
-  }
 }

--- a/src/apps/teams/src/components/TeamCard/TeamCard.js
+++ b/src/apps/teams/src/components/TeamCard/TeamCard.js
@@ -199,10 +199,7 @@ export default class TeamCard extends Component {
 
                           {this.state.isAdmin ? (
                             <i
-                              className={cx(
-                                styles.Remove,
-                                'fa fa-times-circle-o'
-                              )}
+                              className={cx(styles.Remove, 'fas fa-user-slash')}
                               onClick={() => {
                                 if (member.inviteeEmail) {
                                   this.handleCancelInvite(


### PR DESCRIPTION
This UI replaces the previous text field to update the instance domain, to allow users to manage the domains their instance is mapped to.

Three main things:
- Adds Table component: the idea was to make it as independent as possible to consider it for the design system. It may need some tweaks for that.
- Adds the UI and store logic for retrieving, adding and deleting domain names.

![domains-ui](https://user-images.githubusercontent.com/3080957/78930300-79b0b500-7a69-11ea-8e2f-8978aee23b25.gif)
