### PR TITLE
Fixes Issue 130

### DIFF
--- a/src/apps/properties/src/components/Table/Table.less
+++ b/src/apps/properties/src/components/Table/Table.less
@@ -6,6 +6,7 @@
     display: grid;
     grid-auto-flow: row;
     grid-gap: 8px;
+    width: 100%;
   }
 
   .TableContent {

--- a/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
+++ b/src/apps/properties/src/views/PropertyOverview/PropertyOverview.js
@@ -53,16 +53,17 @@ class PropertyOverview extends Component {
     }
   }
 
-  getCustomDomains = routeProps => {
+  getCustomDomains = () => {
     const customDomains =
-      this.props.domains &&
-      this.props.domains.filter(item => {
-        const domainParts = item.domain.split('.')
-        const customDomain = domainParts
-          .slice(Math.max(domainParts.length - 2, 0))
-          .join('.')
-        return customDomain !== 'zesty.dev' && customDomain !== 'zesty.site'
-      })
+      this.props.domains && Array.isArray(this.props.domains)
+        ? this.props.domains.filter(item => {
+            const domainParts = item.domain.split('.')
+            const customDomain = domainParts
+              .slice(Math.max(domainParts.length - 2, 0))
+              .join('.')
+            return customDomain !== 'zesty.dev' && customDomain !== 'zesty.site'
+          })
+        : []
     return customDomains
   }
 
@@ -112,26 +113,13 @@ class PropertyOverview extends Component {
             <Route
               path="/instances/:siteZUID/launch"
               render={routeProps => {
-                const customDomains = this.getCustomDomains(routeProps)
                 return (
-                  <>
-                    <LaunchWizard
-                      {...routeProps}
-                      isAdmin={this.props.isAdmin}
-                      dispatch={this.props.dispatch}
-                      site={this.props.site}
-                    />
-                    {customDomains && customDomains.length > 0 && (
-                      <Meta
-                        {...routeProps}
-                        isAdmin={this.props.isAdmin}
-                        dispatch={this.props.dispatch}
-                        site={this.props.site}
-                        domains={this.props.domains}
-                        customDomains={customDomains}
-                      />
-                    )}
-                  </>
+                  <LaunchWizard
+                    {...routeProps}
+                    isAdmin={this.props.isAdmin}
+                    dispatch={this.props.dispatch}
+                    site={this.props.site}
+                  />
                 )
               }}
             />
@@ -140,8 +128,26 @@ class PropertyOverview extends Component {
               path="/instances/:siteZUID"
               exact
               render={routeProps => {
-                const customDomains = this.getCustomDomains(routeProps)
-                return customDomains && customDomains.length > 0 ? (
+                const customDomains = this.getCustomDomains()
+                return (
+                  customDomains &&
+                  customDomains.length === 0 && (
+                    <LaunchWizard
+                      {...routeProps}
+                      isAdmin={this.props.isAdmin}
+                      dispatch={this.props.dispatch}
+                      site={this.props.site}
+                    />
+                  )
+                )
+              }}
+            />
+
+            <Route
+              path="/instances/:siteZUID"
+              render={routeProps => {
+                const customDomains = this.getCustomDomains()
+                return (
                   <Meta
                     {...routeProps}
                     isAdmin={this.props.isAdmin}
@@ -149,13 +155,6 @@ class PropertyOverview extends Component {
                     site={this.props.site}
                     domains={this.props.domains}
                     customDomains={customDomains}
-                  />
-                ) : (
-                  <LaunchWizard
-                    {...routeProps}
-                    isAdmin={this.props.isAdmin}
-                    dispatch={this.props.dispatch}
-                    site={this.props.site}
                   />
                 )
               }}

--- a/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.js
@@ -107,41 +107,44 @@ export default class Meta extends Component {
             </h2>
           </CardHeader>
           <CardContent className={styles.CardContent}>
-            <div className={styles.TableAction}>
-              {this.props.isAdmin ? (
-                <Domain
-                  siteZUID={this.props.site.ZUID}
-                  site={this.props.site}
-                  dispatch={this.props.dispatch}
-                  domain={this.props.domains}
-                  customDomains={this.props.customDomains}
-                />
-              ) : (
-                <p className={styles.domain}>
-                  <em>
-                    <i
-                      className="fa fa-exclamation-triangle"
-                      aria-hidden="true"
+            {this.props.customDomains && this.props.customDomains.length > 0 && (
+              <>
+                <div className={styles.TableAction}>
+                  {this.props.isAdmin ? (
+                    <Domain
+                      siteZUID={this.props.site.ZUID}
+                      site={this.props.site}
+                      dispatch={this.props.dispatch}
+                      domain={this.props.domains}
+                      customDomains={this.props.customDomains}
                     />
-                    &nbsp; You must be this instance's owner or admin to manage
-                    domains
-                  </em>
-                </p>
-              )}
-            </div>
-            {this.props.domains ? (
-              <Table
-                arrangement="3 1 1 1"
-                data={domainsTable}
-                siteZUID={this.props.site.ZUID}
-                dispatch={this.props.dispatch}
-                isAdmin={this.props.isAdmin}
-                actions={this.renderDomainsActions}
-              />
-            ) : (
-              <em>Ask your instance owner to set a domain</em>
+                  ) : (
+                    <p className={styles.domain}>
+                      <em>
+                        <i
+                          className="fa fa-exclamation-triangle"
+                          aria-hidden="true"
+                        />
+                        &nbsp; You must be this instance's owner or admin to
+                        manage domains
+                      </em>
+                    </p>
+                  )}
+                </div>
+                {this.props.domains ? (
+                  <Table
+                    arrangement="3 1 1 1"
+                    data={domainsTable}
+                    siteZUID={this.props.site.ZUID}
+                    dispatch={this.props.dispatch}
+                    isAdmin={this.props.isAdmin}
+                    actions={this.renderDomainsActions}
+                  />
+                ) : (
+                  <em>Ask your instance owner to set a domain</em>
+                )}
+              </>
             )}
-
             <article>
               <p className={styles.setting}>
                 <span className={styles.title}>Created On:</span>{' '}

--- a/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Meta/Meta.js
@@ -83,6 +83,7 @@ export default class Meta extends Component {
   render() {
     const domainsTable =
       this.props.domains &&
+      Array.isArray(this.props.domains) &&
       this.props.domains.map(domainData => {
         const { domain, branch, createdAt } = domainData
         return {


### PR DESCRIPTION
Fixes 3 main bugs reported on https://github.com/zesty-io/accounts-ui/issues/130

- checks for `domain` prop type before .map
- Aligns domains table headers for larger screens
- Shows Meta section even if custom domains are not set

<img width="673" alt="Screen Shot 2020-04-17 at 12 44 34" src="https://user-images.githubusercontent.com/3080957/79598395-7c368e80-80a9-11ea-8861-4d4b2948abed.png">
<img width="1670" alt="Screen Shot 2020-04-17 at 12 37 36" src="https://user-images.githubusercontent.com/3080957/79598403-7f317f00-80a9-11ea-8397-f5da8dfa1bb2.png">
 