### PR TITLE
fix(teamcard): treat cancelled and declined invites as deleted invites

### DIFF
--- a/src/apps/teams/src/store/teamMembers.js
+++ b/src/apps/teams/src/store/teamMembers.js
@@ -46,7 +46,9 @@ export function fetchTeamMemberInvites(teamZUID) {
     ).then(res => {
       dispatch({
         type: 'FETCH_TEAM_MEMBER_INVITES_SUCCESS',
-        data: res.data.filter(member => !member.accepted),
+        data: res.data.filter(
+          member => !member.accepted && !member.cancelled && !member.declined
+        ),
         teamZUID
       })
       return res.data


### PR DESCRIPTION
Filter the three cases synonymously.

Closes https://github.com/zesty-io/accounts-api/issues/151