### PR TITLE
Fix link path and broken close button

### DIFF
--- a/src/apps/properties/src/views/PropertiesList/components/ColumnList/components/InstanceRow/InstanceRow.js
+++ b/src/apps/properties/src/views/PropertiesList/components/ColumnList/components/InstanceRow/InstanceRow.js
@@ -9,6 +9,7 @@ import { Url } from '@zesty-io/core/Url'
 
 export default function InstanceRow(props) {
   const { site } = props
+
   return (
     <span className={styles.row}>
       <InstanceFavorite
@@ -34,7 +35,7 @@ export default function InstanceRow(props) {
         <Url
           className={styles.action}
           target="_blank"
-          href={`${CONFIG.MANAGER_URL_PROTOCOL}${site.randomHashID}${CONFIG.MANAGER_URL}`}>
+          href={`${CONFIG.MANAGER_URL_PROTOCOL}${site.randomHashID}${CONFIG.NEW_MANAGER_URL}`}>
           <i className="fas fa-edit" aria-hidden="true" />
         </Url>
       ) : (

--- a/src/apps/properties/src/views/PropertiesList/components/GridList/GridList.js
+++ b/src/apps/properties/src/views/PropertiesList/components/GridList/GridList.js
@@ -49,7 +49,7 @@ export default connect(state => state)(props => {
                   className={styles.CloseOverview}
                   id="closeOverviewButton"
                   onClick={close}>
-                  <i className="fa fa-times-circle-o" aria-hidden="true" />
+                  <i className="fa fa-times" aria-hidden="true" />
                 </Button>
                 <PropertyOverview {...props} />
               </div>

--- a/src/apps/properties/src/views/PropertiesList/components/GridList/GridList.less
+++ b/src/apps/properties/src/views/PropertiesList/components/GridList/GridList.less
@@ -63,7 +63,7 @@
         padding: 3px;
         background: none;
         border: none;
-        font-size: 1.8em;
+        font-size: 20px;
         margin: 0;
         color: #404c65;
         text-shadow: 1px 1px 1px #fff;


### PR DESCRIPTION
fixes #167 

1) Swapped out link to point to new manager-ui instead of legacy.
2) Fixed close button in grid view that was broken 

Before
![Screen Shot 2021-02-04 at 11 14 36 AM](https://user-images.githubusercontent.com/22800749/106945513-bdea0180-66dc-11eb-8b33-931281f11c48.png)

Fixed
![Screen Shot 2021-02-04 at 11 29 30 AM](https://user-images.githubusercontent.com/22800749/106945527-c4787900-66dc-11eb-82d9-274c6bd0574c.png)


