### PR TITLE
Swapped out 1fr unit to max-content

### DIFF
--- a/src/apps/properties/src/views/PropertyOverview/PropertyOverview.less
+++ b/src/apps/properties/src/views/PropertyOverview/PropertyOverview.less
@@ -10,12 +10,10 @@
     position: sticky;
     top: 0;
     z-index: 10;
-    display: flex;
     align-items: center;
-
     display: grid;
     grid-gap: 12px;
-    grid-template-columns: auto 120px 124px 1fr;
+    grid-template-columns: max-content 120px 124px max-content;
 
     .manager {
       padding: 0 !important;


### PR DESCRIPTION
fixes #171 

Legacy Manager buttons no longer takes 100% width 

![Screen Shot 2021-02-04 at 1 32 27 PM](https://user-images.githubusercontent.com/22800749/106957886-6dc76b00-66ed-11eb-9b54-6270cfbff51b.png)

 remove unused display flex