### PR TITLE
hardcoding http into renderDomain to prevent turn off redirects from …

### DIFF
--- a/src/apps/properties/src/components/WebsiteCard/WebsiteCard.js
+++ b/src/apps/properties/src/components/WebsiteCard/WebsiteCard.js
@@ -40,7 +40,7 @@ export default connect(state => state)(props => {
       return domains.map(dom => (
         <Url
           key={dom.ZUID}
-          href={`//${dom.domain}`}
+          href={`http://${dom.domain}`}
           target="_blank"
           title="View live domain">
           {dom.domain}


### PR DESCRIPTION
Fixes #165 
Hardcoding http into the renderDomain to prevent instances with turned off ssl protocol from redirecting to `This site can't be reached` page in the browser.  