### PR TITLE
added infotip for domain instructions

### DIFF
--- a/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
+++ b/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.js
@@ -6,6 +6,7 @@ import { notify } from '../../../../../../../shell/store/notifications'
 import { Input } from '@zesty-io/core/Input'
 import { Button } from '@zesty-io/core/Button'
 import { DropDownFieldType } from '@zesty-io/core/DropDownFieldType'
+import { Infotip } from '@zesty-io/core/Infotip'
 
 import styles from './Domain.less'
 export default class Domain extends Component {
@@ -72,6 +73,11 @@ export default class Domain extends Component {
   render() {
     return (
       <label className={styles.Domain}>
+        <Infotip className={styles.Infotip}>
+          Enter the domain root. Do not include protocol (eg. http) or trailing
+          slash. For example, if your domain is example.com, you'll enter
+          example.com.
+        </Infotip>
         <div className={styles.DomainInput}>
           <Input
             name="domain"

--- a/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.less
+++ b/src/apps/properties/src/views/PropertyOverview/components/Domain/Domain.less
@@ -6,7 +6,13 @@
   grid-gap: 8px;
   padding: 16px 0;
   width: 100%;
+  position: relative;
 
+  .Infotip {
+    position: absolute;
+    top: 0;
+    left: 0;
+  }
   .DomainInput {
     input {
       display: block;


### PR DESCRIPTION
fixes #178 
Added info tip for users to better understand the correct domain input format.

<img width="904" alt="Screen Shot 2021-04-21 at 11 40 45 AM" src="https://user-images.githubusercontent.com/22800749/115604920-c511bc00-a296-11eb-8338-03cd46cdb88d.png">
