### PR TITLE
removing duplicated action

### DIFF
--- a/src/apps/properties/src/views/PropertiesList/components/GridList/GridList.js
+++ b/src/apps/properties/src/views/PropertiesList/components/GridList/GridList.js
@@ -47,8 +47,7 @@ export default connect(state => state)(props => {
               <div className={styles.PropertyOverviewWrap}>
                 <Button
                   className={styles.CloseOverview}
-                  id="closeOverviewButton"
-                  onClick={close}>
+                  id="closeOverviewButton">
                   <i className="fa fa-times" aria-hidden="true" />
                 </Button>
                 <PropertyOverview {...props} />


### PR DESCRIPTION
Was trying to resolve `Cannot set property 'innerHTML' of null` for ticket ACCOUNTS-UI-16M,K,L,J,H,G found this bug in the mean time. 

While in grid view the close button is fired off twice, removed the extra onClick call. 


