### PR TITLE
fix: use private Route to guard LoadUser and AppWithRouter

### DIFF
--- a/src/shell/views/App/App.js
+++ b/src/shell/views/App/App.js
@@ -96,18 +96,23 @@ class LoadUser extends Component {
     this.__mounted = false
   }
   render() {
-    if (this.props.auth) {
-      return (
-        <WithLoader
-          condition={!this.state.loadingUser}
-          message="Finding Your Account">
-          {this.props.children}
-        </WithLoader>
-      )
-    } else {
-      return <Redirect to="/login" />
-    }
+    return (
+      <WithLoader
+        condition={!this.state.loadingUser}
+        message="Finding Your Account">
+        {this.props.children}
+      </WithLoader>
+    )
   }
+}
+
+const PrivateRoute = ({ auth, children, ...rest }) => {
+  return (
+    <Route
+      {...rest}
+      render={() => (auth ? children : <Redirect to={'/login'} />)}
+    />
+  )
 }
 
 export default withRouter(
@@ -124,12 +129,11 @@ export default withRouter(
           <Route path="/verify-email" component={VerifyEmail} />
           <Route path="/resend-email" component={ResendEmail} />
 
-          <LoadUser
-            auth={props.auth.valid}
-            userZUID={props.user.ZUID}
-            dispatch={props.dispatch}>
-            <AppWithRouter user={props.user} dispatch={props.dispatch} />
-          </LoadUser>
+          <PrivateRoute auth={props.auth.valid}>
+            <LoadUser userZUID={props.user.ZUID} dispatch={props.dispatch}>
+              <AppWithRouter user={props.user} dispatch={props.dispatch} />
+            </LoadUser>
+          </PrivateRoute>
         </Switch>
       </React.Fragment>
     )


### PR DESCRIPTION
current behavior of `<LoadUser>` is dependent on undefined React Router behavior since it's not returning a `<Route>` as a child of `<Switch>`.
this PR adds `PrivateRoute` wrapper that renders a `<Route>` wrapping the children if auth passes.
In this way all the `Switch` children are `Route`s and we are back in safe territory with React Router API.
As a side effect, it appears to fix the 2fa login bug.
fixes #204 